### PR TITLE
changed truncate from 75 chars to 50

### DIFF
--- a/resources/js/screens/logs/index.vue
+++ b/resources/js/screens/logs/index.vue
@@ -18,7 +18,7 @@
         </tr>
 
         <template slot="row" slot-scope="slotProps">
-            <td :title="slotProps.entry.content.message">{{truncate(slotProps.entry.content.message, 75)}}</td>
+            <td :title="slotProps.entry.content.message">{{truncate(slotProps.entry.content.message, 50)}}</td>
 
             <td class="table-fit">
                 <span class="badge font-weight-light" :class="'badge-'+logLevelClass(slotProps.entry.content.level)">


### PR DESCRIPTION
This should fit better on screen and fix Issue #886 which I reported.
As the screen shot shows, when it's up to the 75 limit it messes up the styling.

<img width="1048" alt="Screenshot 2020-05-05 at 08 46 09" src="https://user-images.githubusercontent.com/1168291/81044822-ef634180-8eac-11ea-8907-58c2bb4767ce.png">
